### PR TITLE
Add dependency to libexif package on mingw

### DIFF
--- a/exif.gemspec
+++ b/exif.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 0.8.1'
   spec.add_development_dependency 'rake-compiler', '~> 1.0.4'
   spec.add_development_dependency 'minitest', '~> 5.11.3'
+  spec.metadata['msys2_mingw_dependencies'] = 'libexif'
 end


### PR DESCRIPTION
RubyInstaller2 supports metadata tags for the installation of dependent MSYS2/MINGW libraries. The exif gem requires the mingw-libexif package to be installed on the system, which the gem installer takes care of, when this tag is set.

The feature is documented here:
https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency